### PR TITLE
Introduce RedirectEnvRestorer and VarEnvRestorer traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `RedirectEnvRestorer` trait to abstract over `RedirectRestorer` and other implementations
 - Added `spawn_with_local_redirections_and_restorer` to allow specifying a specific `RedirectEnvRestorer` implementation
+- Added `VarEnvRestorer` trait to abstract over `VarRestorer` and other implementations
 
 ### Changed
 - `eval_redirects_or_cmd_words_with_restorer` is now generic over a `RedirectEnvRestorer`
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Deprecated
 - Deprecated most of the direct methods on `RedirectRestorer` in favor of the `RedirectEnvRestorer` trait
+- Deprecated most of the direct methods on `VarRestorer` in favor of the `VarEnvRestorer` trait
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
-## 0.1.0
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-- First release
+## [Unreleased]
+### Added
+- Added `RedirectEnvRestorer` trait to abstract over `RedirectRestorer` and other implementations
+- Added `spawn_with_local_redirections_and_restorer` to allow specifying a specific `RedirectEnvRestorer` implementation
+
+### Changed
+- `eval_redirects_or_cmd_words_with_restorer` is now generic over a `RedirectEnvRestorer`
+- `EvalRedirectOrCmdWordError` is also generic over any `RedirectEnvRestorer`, but defaults to `RedirectRestorer` for backward compatibility
+- `eval_redirects_or_var_assignments_with_restorer` is now generic over a `RedirectEnvRestorer`
+- `EvalRedirectOrVarAssig` is also generic over any `RedirectEnvRestorer`, but defaults to `RedirectRestorer` for backward compatibility
+- `LocalRedirections` is also generic over any `RedirectEnvRestorer`, but defaults to `RedirectRestorer` for backward compatibility
+
+### Deprecated
+- Deprecated most of the direct methods on `RedirectRestorer` in favor of the `RedirectEnvRestorer` trait
+
+### Removed
+### Fixed
+### Security
+### Breaking
+
+## [0.1.0] - 2017-08-21
+- First release!
+
+[Unreleased]: https://github.com/ipetkov/conch-runtime/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ipetkov/conch-runtime/compare/v0.1.0...HEAD

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -29,7 +29,7 @@ pub use self::fd::{FileDescEnv, FileDescEnvironment};
 pub use self::func::{FnEnv, FunctionEnvironment, UnsetFunctionEnvironment};
 pub use self::last_status::{LastStatusEnv, LastStatusEnvironment};
 pub use self::reversible_redirect::{RedirectEnvRestorer, RedirectRestorer};
-pub use self::reversible_var::VarRestorer;
+pub use self::reversible_var::{VarEnvRestorer, VarRestorer};
 pub use self::string_wrapper::StringWrapper;
 pub use self::var::{ExportedVariableEnvironment, VarEnv, VariableEnvironment,
                     UnsetVariableEnvironment};

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -28,7 +28,7 @@ pub use self::executable::{Child, ExecutableData, ExecEnv, ExecutableEnvironment
 pub use self::fd::{FileDescEnv, FileDescEnvironment};
 pub use self::func::{FnEnv, FunctionEnvironment, UnsetFunctionEnvironment};
 pub use self::last_status::{LastStatusEnv, LastStatusEnvironment};
-pub use self::reversible_redirect::RedirectRestorer;
+pub use self::reversible_redirect::{RedirectEnvRestorer, RedirectRestorer};
 pub use self::reversible_var::VarRestorer;
 pub use self::string_wrapper::StringWrapper;
 pub use self::var::{ExportedVariableEnvironment, VarEnv, VariableEnvironment,

--- a/src/spawn/simple.rs
+++ b/src/spawn/simple.rs
@@ -2,8 +2,8 @@ use {CANCELLED_TWICE, Fd, EXIT_CMD_NOT_EXECUTABLE, EXIT_CMD_NOT_FOUND, EXIT_ERRO
      ExitStatus, POLLED_TWICE, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO};
 use env::{AsyncIoEnvironment, ExecutableEnvironment, ExecutableData, ExportedVariableEnvironment,
           FileDescEnvironment, FunctionEnvironment, RedirectEnvRestorer, RedirectRestorer,
-          SetArgumentsEnvironment, VarRestorer, VariableEnvironment, UnsetVariableEnvironment,
-          WorkingDirectoryEnvironment};
+          SetArgumentsEnvironment, VarEnvRestorer, VarRestorer, VariableEnvironment,
+          UnsetVariableEnvironment, WorkingDirectoryEnvironment};
 use error::{CommandError, RedirectionError};
 use eval::{eval_redirects_or_cmd_words_with_restorer, eval_redirects_or_var_assignments,
            EvalRedirectOrCmdWord, EvalRedirectOrCmdWordError, EvalRedirectOrVarAssig,
@@ -314,7 +314,7 @@ impl<R, V, W, IV, IW, E: ?Sized, S> EnvFuture<E> for SimpleCommand<R, V, W, IV, 
                     match f.poll(env) {
                         Ok(Async::NotReady) => return Ok(Async::NotReady),
                         ret => {
-                            let (mut redirect_restorer, var_restorer) = restorers.take()
+                            let (mut redirect_restorer, mut var_restorer) = restorers.take()
                                 .expect(POLLED_TWICE);
 
                             redirect_restorer.restore(env);
@@ -368,7 +368,7 @@ impl<R, V, W, IV, IW, E: ?Sized, S> EnvFuture<E> for SimpleCommand<R, V, W, IV, 
             State::Eval(ref mut eval) => eval.cancel(env),
             State::Func(ref mut restorers, ref mut f) => {
                 f.cancel(env);
-                let (mut redirect_restorer, var_restorer) = restorers.take().expect(CANCELLED_TWICE);
+                let (mut redirect_restorer, mut var_restorer) = restorers.take().expect(CANCELLED_TWICE);
                 redirect_restorer.restore(env);
                 var_restorer.restore(env);
             },

--- a/src/spawn/simple.rs
+++ b/src/spawn/simple.rs
@@ -1,8 +1,9 @@
 use {CANCELLED_TWICE, Fd, EXIT_CMD_NOT_EXECUTABLE, EXIT_CMD_NOT_FOUND, EXIT_ERROR, EXIT_SUCCESS,
      ExitStatus, POLLED_TWICE, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO};
 use env::{AsyncIoEnvironment, ExecutableEnvironment, ExecutableData, ExportedVariableEnvironment,
-          FileDescEnvironment, FunctionEnvironment, RedirectRestorer, SetArgumentsEnvironment,
-          VarRestorer, VariableEnvironment, UnsetVariableEnvironment, WorkingDirectoryEnvironment};
+          FileDescEnvironment, FunctionEnvironment, RedirectEnvRestorer, RedirectRestorer,
+          SetArgumentsEnvironment, VarRestorer, VariableEnvironment, UnsetVariableEnvironment,
+          WorkingDirectoryEnvironment};
 use error::{CommandError, RedirectionError};
 use eval::{eval_redirects_or_cmd_words_with_restorer, eval_redirects_or_var_assignments,
            EvalRedirectOrCmdWord, EvalRedirectOrCmdWordError, EvalRedirectOrVarAssig,
@@ -148,7 +149,7 @@ enum EvalState<R, V, W, IV, IW, E: ?Sized>
           W: WordEval<E>,
           E: FileDescEnvironment,
 {
-    InitVars(EvalRedirectOrVarAssig<R, V, W, IV, E>, Option<IW>),
+    InitVars(EvalRedirectOrVarAssig<R, V, W, IV, E, RedirectRestorer<E>>, Option<IW>),
     InitWords(Option<HashMap<V, W::EvalResult>>, EvalRedirectOrCmdWord<R, W, IW, E>),
     Gone,
 }
@@ -268,7 +269,7 @@ impl<R, V, W, IV, IW, E: ?Sized, S> EnvFuture<E> for SimpleCommand<R, V, W, IV, 
                     Err(RedirectOrWordError::Redirect(e)) => return Err(e.into()),
                     Err(RedirectOrWordError::Word(e)) => return Err(e.into()),
 
-                    Ok(Async::Ready((red_restorer_inner, vars_inner, mut words_inner))) => {
+                    Ok(Async::Ready((mut red_restorer_inner, vars_inner, mut words_inner))) => {
                         if words_inner.is_empty() {
                             // "Empty" command which is probably just assigning variables.
                             // Any redirect side effects have already been applied.
@@ -313,7 +314,7 @@ impl<R, V, W, IV, IW, E: ?Sized, S> EnvFuture<E> for SimpleCommand<R, V, W, IV, 
                     match f.poll(env) {
                         Ok(Async::NotReady) => return Ok(Async::NotReady),
                         ret => {
-                            let (redirect_restorer, var_restorer) = restorers.take()
+                            let (mut redirect_restorer, var_restorer) = restorers.take()
                                 .expect(POLLED_TWICE);
 
                             redirect_restorer.restore(env);
@@ -344,6 +345,7 @@ impl<R, V, W, IV, IW, E: ?Sized, S> EnvFuture<E> for SimpleCommand<R, V, W, IV, 
 
         // Now that we've got all the redirections we care about having the
         // child inherit, we can do the environment cleanup right now.
+        let mut redirect_restorer = redirect_restorer;
         redirect_restorer.restore(env);
 
         let original_env_vars = env.env_vars().iter()
@@ -366,7 +368,7 @@ impl<R, V, W, IV, IW, E: ?Sized, S> EnvFuture<E> for SimpleCommand<R, V, W, IV, 
             State::Eval(ref mut eval) => eval.cancel(env),
             State::Func(ref mut restorers, ref mut f) => {
                 f.cancel(env);
-                let (redirect_restorer, var_restorer) = restorers.take().expect(CANCELLED_TWICE);
+                let (mut redirect_restorer, var_restorer) = restorers.take().expect(CANCELLED_TWICE);
                 redirect_restorer.restore(env);
                 var_restorer.restore(env);
             },

--- a/tests/redirect_or_cmd_word.rs
+++ b/tests/redirect_or_cmd_word.rs
@@ -39,7 +39,7 @@ fn smoke() {
         &env
     );
 
-    let (restorer, words) = lp.run(poll_fn(|| future.poll(&mut env))).unwrap();
+    let (mut restorer, words) = lp.run(poll_fn(|| future.poll(&mut env))).unwrap();
 
     assert_eq!(env.file_desc(1), Some((&fdes, Permissions::Write)));
     restorer.restore(&mut env);

--- a/tests/redirect_or_var_assig.rs
+++ b/tests/redirect_or_var_assig.rs
@@ -48,7 +48,7 @@ fn smoke() {
         &env
     );
 
-    let (restorer, vars) = lp.run(poll_fn(|| future.poll(&mut env))).unwrap();
+    let (mut restorer, vars) = lp.run(poll_fn(|| future.poll(&mut env))).unwrap();
 
     assert_eq!(env.file_desc(1), Some((&fdes, Permissions::Write)));
     restorer.restore(&mut env);

--- a/tests/reversible_redirect.rs
+++ b/tests/reversible_redirect.rs
@@ -3,7 +3,7 @@ extern crate conch_runtime;
 use conch_runtime::io::{FileDesc, Permissions};
 use conch_runtime::Fd;
 use conch_runtime::env::{AsyncIoEnvironment, FileDescEnvironment, PlatformSpecificRead,
-                         PlatformSpecificWriteAll, RedirectRestorer};
+                         PlatformSpecificWriteAll, RedirectRestorer, RedirectEnvRestorer};
 use conch_runtime::eval::RedirectAction;
 use std::collections::HashMap;
 
@@ -73,7 +73,7 @@ fn smoke() {
 
     let env_original = env.clone();
 
-    let mut restorer = RedirectRestorer::new();
+    let restorer: &mut RedirectEnvRestorer<_> = &mut RedirectRestorer::new();
 
     // Existing fd set to multiple other values
     restorer.apply_action(RedirectAction::Open(1, S("x"), Permissions::Read), &mut env).unwrap();

--- a/tests/reversible_var.rs
+++ b/tests/reversible_var.rs
@@ -1,6 +1,6 @@
 extern crate conch_runtime;
 
-use conch_runtime::env::{VarEnv, VarRestorer, VariableEnvironment, UnsetVariableEnvironment};
+use conch_runtime::env::{VarEnv, VarEnvRestorer, VarRestorer, VariableEnvironment, UnsetVariableEnvironment};
 
 #[test]
 fn smoke() {
@@ -19,7 +19,7 @@ fn smoke() {
 
     // Existing values set to multiple other values
     {
-        let mut restorer = VarRestorer::new();
+        let restorer: &mut VarEnvRestorer<_> = &mut VarRestorer::new();
 
         restorer.set_exported_var(key_exported, "some other exported value", true, &mut env);
         restorer.set_exported_var(key_existing, "some other value", false, &mut env);
@@ -31,7 +31,7 @@ fn smoke() {
 
     // Unset existing values
     {
-        let mut restorer = VarRestorer::new();
+        let restorer: &mut VarEnvRestorer<_> = &mut VarRestorer::new();
 
         restorer.unset_var(key_exported, &mut env);
         restorer.unset_var(key_existing, &mut env);
@@ -43,7 +43,7 @@ fn smoke() {
 
     // Unset then set existing values
     {
-        let mut restorer = VarRestorer::new();
+        let restorer: &mut VarEnvRestorer<_> = &mut VarRestorer::new();
 
         restorer.unset_var(key_exported, &mut env);
         restorer.unset_var(key_existing, &mut env);


### PR DESCRIPTION
* This allows us to abstract over other redirect/variable restorer implementations which will be significant when we introduce built in commands (e.g. running `exec < foo` may not want to actually restore redirects)
* Marked all methods directly defined on `RedirectRestorer` and `VarRestorer` as deprecated in favor of their respective new traits
* Also made any applicable futures generic over the respective trait instead of a concrete implementation
