### PR TITLE
Removed aggressive redirect restorer pre-allocations when evaluating redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ backwards compatible manner.
 - Reduced required bounds for implementing `VarEnvRestorer` to just `E: VariableEnvironment`
 - Spawning a simple command now (more) correctly evaluates variable assignments where one
 assignment depends on an earlier one (e.g. `var1=foo var2=${bar:-$var1} env`)
+- Removed aggressive redirect restorer pre-allocations when evaluating redirects: most shell
+scripts will not apply redirects to the majority of commands, nor will they have obscene
+amounts of redirects when they do occur, so we can avoid allocating memory until we really need it.
 
 ### Deprecated
 - Deprecated `eval_redirects_or_var_assignments`, `eval_redirects_or_cmd_words_with_restorer`

--- a/src/eval/redirect_or_cmd_word.rs
+++ b/src/eval/redirect_or_cmd_word.rs
@@ -150,8 +150,6 @@ pub fn eval_redirects_or_cmd_words_with_restorer<R, W, I, E: ?Sized, RR>(
     let (lo, hi) = words.size_hint();
     let size_hint = hi.unwrap_or(lo);
 
-    restorer.reserve(size_hint);
-
     EvalRedirectOrCmdWord {
         redirect_restorer: Some(restorer),
         words: Vec::with_capacity(size_hint),

--- a/src/eval/redirect_or_var_assig.rs
+++ b/src/eval/redirect_or_var_assig.rs
@@ -278,7 +278,6 @@ pub fn eval_redirects_or_var_assignments_with_restorers<R, V, W, I, E: ?Sized, R
     let (lo, hi) = vars.size_hint();
     let size_hint = hi.unwrap_or(lo);
 
-    redirect_restorer.reserve(size_hint);
     var_restorer.reserve(size_hint);
 
     EvalRedirectOrVarAssig2 {


### PR DESCRIPTION
* (From what I've seen anecdotally,) most shell scripts will not apply redirects to the majority of commands, nor will they have obscene amounts of redirects when they do occur, so we can
avoid allocating memory until we really need it.