### PR TITLE
Add a builtin implementation of the `shift` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ except it applies variables directly into the environment and provide a `VarRest
 - Added `VarEnvRestorer2` trait as a correction to the `VarEnvRestorer` interface in a
 backwards compatible manner.
 - Added `ShiftArgumentsEnvironment` as an interface for shifting positional arguments.
+- Added a `spawn::builtin` module for hosting shell-builtin command implementations
+- Added a builtin implementation for the `shift` shell-command
 
 ### Changed
 - Reduced required bounds for implementing `VarEnvRestorer` to just `E: VariableEnvironment`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ top-level = ["conch-parser"]
 
 [dependencies]
 conch-parser = { version = "0.1", optional = true }
+clap        = "2"
 clippy      = { version = "~0.0.80", optional = true }
 futures     = "0.1.14"
 futures-cpupool = "0.1.2"

--- a/src/env/env_impl.rs
+++ b/src/env/env_impl.rs
@@ -20,8 +20,8 @@ use env::{ArgsEnv, ArgumentsEnvironment, AsyncIoEnvironment, ChangeWorkingDirect
           ExecEnv, ExecutableData, ExecutableEnvironment, ExportedVariableEnvironment,
           FileDescEnv, FileDescEnvironment, FnEnv, FunctionEnvironment,
           IsInteractiveEnvironment, LastStatusEnv, LastStatusEnvironment,
-          PlatformSpecificAsyncIoEnv, ReportErrorEnvironment, SetArgumentsEnvironment,
-          StringWrapper, SubEnvironment, UnsetFunctionEnvironment,
+          PlatformSpecificAsyncIoEnv, ReportErrorEnvironment, ShiftArgumentsEnvironment,
+          SetArgumentsEnvironment, StringWrapper, SubEnvironment, UnsetFunctionEnvironment,
           UnsetVariableEnvironment, VarEnv, VariableEnvironment, VirtualWorkingDirEnv,
           WorkingDirectoryEnvironment};
 
@@ -388,6 +388,16 @@ macro_rules! impl_env {
 
             fn set_args(&mut self, new_args: Self::Args) -> Self::Args {
                 self.args_env.set_args(new_args)
+            }
+        }
+
+        impl<A, IO, FD, L, V, EX, WD, N, ERR> ShiftArgumentsEnvironment
+            for $Env<A, IO, FD, L, V, EX, WD, N, ERR>
+            where A: ShiftArgumentsEnvironment,
+                  N: Hash + Eq,
+        {
+            fn shift_args(&mut self, amt: usize) {
+                self.args_env.shift_args(amt)
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 #[cfg(windows)] extern crate kernel32;
 #[cfg(windows)] extern crate winapi;
 
+extern crate clap;
 #[cfg(feature = "conch-parser")]
 extern crate conch_parser;
 #[macro_use] extern crate futures;

--- a/src/spawn/builtin/mod.rs
+++ b/src/spawn/builtin/mod.rs
@@ -1,0 +1,5 @@
+//! Defines methods for spawning shell builtin commands
+
+mod shift;
+
+pub use self::shift::{Shift, shift, SpawnedShift};

--- a/src/spawn/builtin/shift.rs
+++ b/src/spawn/builtin/shift.rs
@@ -1,0 +1,132 @@
+use {EXIT_ERROR, EXIT_SUCCESS, ExitStatus, POLLED_TWICE, Spawn};
+use clap::{App, AppSettings, Arg};
+use env::{ArgumentsEnvironment, ReportErrorEnvironment, ShiftArgumentsEnvironment, StringWrapper};
+use future::{Async, EnvFuture, Poll};
+use futures::future::{FutureResult, ok};
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt;
+use void::Void;
+
+const NUMERIC_ARGUMENT_REQUIRED: &'static str = "numeric argument required";
+
+#[derive(Debug)]
+struct NumericArgumentRequiredError;
+
+impl Error for NumericArgumentRequiredError {
+    fn description(&self) -> &str {
+        NUMERIC_ARGUMENT_REQUIRED
+    }
+}
+
+impl fmt::Display for NumericArgumentRequiredError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+/// Represents a `shift` builtin command.
+///
+/// The `shift` builtin command will shift all shell or function positional
+/// arguments up by the specified amount. For example, shifting by 2 will
+/// result in `$1` holding the previous value of `$3`, `$2` holding the
+/// previous value of `$4`, and so on.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Shift<T> {
+    args: Vec<T>,
+}
+
+/// Creates a new `shift` builtin command with the provided arguments.
+pub fn shift<T>(args: Vec<T>) -> Shift<T> {
+    Shift {
+        args: args,
+    }
+}
+
+/// A future representing a fully spawned `shift` builtin command.
+#[derive(Debug)]
+pub struct SpawnedShift<T> {
+    args: Option<Vec<T>>,
+}
+
+impl<T, E: ?Sized> Spawn<E> for Shift<T>
+    where T: StringWrapper,
+          E: ArgumentsEnvironment + ShiftArgumentsEnvironment + ReportErrorEnvironment,
+{
+    type EnvFuture = SpawnedShift<T>;
+    type Future = FutureResult<ExitStatus, Self::Error>;
+    type Error = Void;
+
+    fn spawn(self, _env: &E) -> Self::EnvFuture {
+        SpawnedShift {
+            args: Some(self.args),
+        }
+    }
+}
+
+macro_rules! try_and_report {
+    ($result:expr, $env:ident) => {
+        match $result {
+            Ok(val) => val,
+            Err(e) => {
+                $env.report_error(&e);
+                return Ok(Async::Ready(ok(EXIT_ERROR)));
+            },
+        }
+    }
+}
+
+impl<T, E: ?Sized> EnvFuture<E> for SpawnedShift<T>
+    where T: StringWrapper,
+          E: ArgumentsEnvironment + ShiftArgumentsEnvironment + ReportErrorEnvironment,
+{
+    type Item = FutureResult<ExitStatus, Self::Error>;
+    type Error = Void;
+
+    fn poll(&mut self, env: &mut E) -> Poll<Self::Item, Self::Error> {
+        const AMT_ARG_NAME: &'static str = "n";
+        const DEFAULT_SHIFT_AMOUNT: &'static str = "1";
+
+        let app = App::new("shift")
+            .setting(AppSettings::NoBinaryName)
+            .setting(AppSettings::DisableVersion)
+            .about("Shifts positional parameters such that (n+1)th parameter becomes $1, and so on")
+            .arg(Arg::with_name(AMT_ARG_NAME)
+                .help("the amount of arguments to shift")
+                .long_help("the amount of arguments to shift. Must be non negative and <= to $#")
+                .validator(|amt| {
+                    amt.parse::<usize>()
+                        .map(|_| ())
+                        .map_err(|_| NUMERIC_ARGUMENT_REQUIRED.into())
+                })
+                .default_value(DEFAULT_SHIFT_AMOUNT)
+            );
+
+        let app_args = self.args.take()
+            .expect(POLLED_TWICE)
+            .into_iter()
+            .map(StringWrapper::into_owned);
+
+        let matches = try_and_report!(app.get_matches_from_safe(app_args), env);
+
+        let amt_arg = matches.value_of_lossy(AMT_ARG_NAME)
+            .unwrap_or(Cow::Borrowed(DEFAULT_SHIFT_AMOUNT))
+            .parse()
+            .map_err(|_| NumericArgumentRequiredError);
+
+        let amt = try_and_report!(amt_arg, env);
+
+        let ret = if amt > env.args_len() {
+            EXIT_ERROR
+        } else {
+            env.shift_args(amt);
+            EXIT_SUCCESS
+        };
+
+        Ok(Async::Ready(ok(ret)))
+    }
+
+    fn cancel(&mut self, _env: &mut E) {
+        self.args.take();
+    }
+}

--- a/src/spawn/mod.rs
+++ b/src/spawn/mod.rs
@@ -21,6 +21,7 @@ mod substitution;
 mod swallow_non_fatal;
 mod vec_sequence;
 
+pub mod builtin;
 #[cfg(feature = "conch-parser")]
 pub mod ast_impl;
 

--- a/tests/shift.rs
+++ b/tests/shift.rs
@@ -1,0 +1,86 @@
+extern crate futures;
+
+use futures::future::poll_fn;
+use std::rc::Rc;
+
+mod support;
+pub use self::support::*;
+
+fn run_shift(
+    env_args_starting: &[&str],
+    shift_args: &[&str],
+    env_args_expected: &[&str],
+    expected_status: ExitStatus,
+) {
+    // NB: Suppress usage dumping errors to console
+    let (mut lp, mut env) = new_env_with_no_fds();
+    env.set_args(Rc::new(env_args_starting.iter()
+        .map(|&s| s.to_owned())
+        .map(Rc::new)
+        .collect::<Vec<_>>()
+    ));
+
+    let shift = builtin::shift(shift_args.iter()
+        .map(|&s| s.to_owned())
+        .collect()
+    );
+
+    let mut shift = shift.spawn(&env);
+    let exit = lp.run(poll_fn(|| shift.poll(&mut env)).flatten())
+        .expect("command failed");
+
+    assert_eq!(exit, expected_status);
+
+    let env_args_expected = env_args_expected.iter()
+        .map(|&s| s.to_owned())
+        .map(Rc::new)
+        .collect::<Vec<_>>();
+    assert_eq!(env.args(), env_args_expected);
+}
+
+#[test]
+fn shift_with_args() {
+    let args = &["a", "b", "d", "e", "f"];
+    run_shift(args, &["3"], &args[3..], EXIT_SUCCESS);
+}
+
+#[test]
+fn shift_no_args_shifts_by_one() {
+    let args = &["a", "b"];
+    run_shift(args, &[], &args[1..], EXIT_SUCCESS);
+}
+
+#[test]
+fn shift_negative_arg_does_nothing_and_exit_with_error() {
+    let args = &["a", "b"];
+    run_shift(args, &["-5"], args, EXIT_ERROR);
+}
+
+#[test]
+fn shift_large_arg_does_nothing_and_exit_with_error() {
+    let args = &["a", "b"];
+    run_shift(args, &["3"], args, EXIT_ERROR);
+}
+
+#[test]
+fn shift_non_numeric_arg_does_nothing_and_exit_with_error() {
+    let args = &["a", "b"];
+    run_shift(args, &["foobar"], args, EXIT_ERROR);
+}
+
+#[test]
+fn shift_multiple_arg_does_nothing_and_exit_with_error() {
+    let args = &["a", "b"];
+    run_shift(args, &["1", "2"], args, EXIT_ERROR);
+}
+
+#[test]
+#[should_panic]
+fn polling_canceled_shift_panics() {
+    let (_, mut env) = new_env_with_no_fds();
+    let mut shift = builtin::shift(Vec::<Rc<String>>::new())
+        .spawn(&env);
+
+    shift.cancel(&mut env);
+    let _ = shift.poll(&mut env);
+}

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -22,6 +22,7 @@ pub use self::conch_runtime::env::*;
 pub use self::conch_runtime::error::*;
 pub use self::conch_runtime::eval::*;
 pub use self::conch_runtime::future::*;
+pub use self::conch_runtime::spawn::*;
 pub use self::futures::{Async, Future, Poll};
 pub use self::tokio_core::reactor::Core;
 


### PR DESCRIPTION
* Added a new `builtin` module under `spawn` for any methods relating
to spawning builtin commands
* The new `shift` command implementation is not curretly picked up when
executing a simple command, due to the breaking changes necessary to do
so