### PR TITLE
Update `pwd` behavior with multiple `-L` or `-P` flags

### DIFF
--- a/src/spawn/builtin/pwd.rs
+++ b/src/spawn/builtin/pwd.rs
@@ -78,19 +78,15 @@ impl<T, E: ?Sized> EnvFuture<E> for SpawnedPwd<T>
             .setting(AppSettings::DisableVersion)
             .about("Prints the absolute path name of the current working directory")
             .arg(Arg::with_name(ARG_LOGICAL)
-                 .short("L")
+                 .short(ARG_LOGICAL)
                  .multiple(true)
-                 // POSIX specifies that if both flags are provided, then the last one
-                 // takes effect, but clap does not appear to support determining this
-                 .conflicts_with(ARG_PHYSICAL)
+                 .overrides_with(ARG_PHYSICAL)
                  .help("Display the logical current working directory.")
             )
             .arg(Arg::with_name(ARG_PHYSICAL)
-                 .short("P")
+                 .short(ARG_PHYSICAL)
                  .multiple(true)
-                 // POSIX specifies that if both flags are provided, then the last one
-                 // takes effect, but clap does not appear to support determining this
-                 .conflicts_with(ARG_LOGICAL)
+                 .overrides_with(ARG_LOGICAL)
                  .help("Display the physical current working directory (all symbolic links resolved).")
             );
 

--- a/tests/pwd.rs
+++ b/tests/pwd.rs
@@ -132,6 +132,12 @@ fn no_arg_behaves_as_physical_if_dot_components_present() {
 }
 
 #[test]
+fn last_specified_flag_wins() {
+    run_pwd(false, &["-L", "-P", "-L"], false);
+    run_pwd(false, &["-P", "-L", "-P"], true);
+}
+
+#[test]
 fn successful_if_no_stdout() {
     let (mut lp, env) = new_env_with_no_fds();
     let pwd = builtin::pwd(Vec::<Rc<String>>::new());


### PR DESCRIPTION
* I had originally missed that clap supports an `overrides_with`
option, which behaves like POSIX describes: the last flag that was
specified "wins" and unsets the previous one