### PR TITLE
Refactor builtins so have less boilerplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,16 @@ addons:
       - binutils-dev # required for the --verify flag of kcov
       - libiberty-dev
 
-rust:
-  - nightly
-  - beta
-  - stable
-  - 1.19.0
+matrix:
+  include:
+    - rust: nightly
+    - rust: beta
+    - rust: stable
+      after_success:
+        - ./ci/install-kcov.sh && ./ci/coverage.sh
+    - rust: 1.20.0
+    - os: osx
+      rust: stable
 
 branches:
   only:
@@ -37,9 +42,6 @@ script:
       cargo test --no-fail-fast --verbose -j 1
     )
   - cargo doc --no-deps
-after_success:
-  # NB: kcov only works on linux
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./ci/install-kcov.sh && ./ci/coverage.sh; fi
 
 env:
   global:
@@ -49,7 +51,3 @@ env:
 notifications:
   email:
     on_success: never
-
-os:
-  - linux
-  - osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,14 @@ except it applies variables directly into the environment and provide a `VarRest
 backwards compatible manner.
 - Added `ShiftArgumentsEnvironment` as an interface for shifting positional arguments.
 - Added a `spawn::builtin` module for hosting shell-builtin command implementations
-- Added a builtin implementations for the `shift`, `:`, `true`, `false`, `pwd, and `echo`
-shell-commands
+- Added a builtin implementations for the following shell commands:
+ - `shift`
+ - `:`
+ - `true`
+ - `false`
+ - `cd`
+ - `pwd`
+ - `echo`
 - Added a `NormalizedPath` wrapper for working with logically or physically normalized paths
 
 ### Changed

--- a/src/spawn/builtin/colon.rs
+++ b/src/spawn/builtin/colon.rs
@@ -1,44 +1,17 @@
-use {EXIT_SUCCESS, ExitStatus, Spawn};
-use future::{Async, EnvFuture, Poll};
-use void::Void;
+use EXIT_SUCCESS;
 
-/// Represents a `:` builtin command.
-///
-/// The `:` command has no effect, and exists as a placeholder for word
-/// and redirection expansions.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct Colon;
+impl_trivial_builtin_cmd! {
+    /// Represents a `:` builtin command.
+    ///
+    /// The `:` command has no effect, and exists as a placeholder for word
+    /// and redirection expansions.
+    pub struct Colon;
 
-/// Creates a new `:` builtin command.
-pub fn colon() -> Colon {
-    Colon
-}
+    /// Creates a new `:` builtin command.
+    pub fn colon();
 
-/// A future representing a fully spawned `:` builtin command.
-#[must_use = "futures do nothing unless polled"]
-#[derive(Debug)]
-#[allow(missing_copy_implementations)]
-pub struct SpawnedColon;
+    /// A future representing a fully spawned `:` builtin command.
+    pub struct SpawnedColon;
 
-impl<E: ?Sized> Spawn<E> for Colon {
-    type EnvFuture = SpawnedColon;
-    type Future = ExitStatus;
-    type Error = Void;
-
-    fn spawn(self, _env: &E) -> Self::EnvFuture {
-        SpawnedColon
-    }
-}
-
-impl<E: ?Sized> EnvFuture<E> for SpawnedColon {
-    type Item = ExitStatus;
-    type Error = Void;
-
-    fn poll(&mut self, _env: &mut E) -> Poll<Self::Item, Self::Error> {
-        Ok(Async::Ready(EXIT_SUCCESS))
-    }
-
-    fn cancel(&mut self, _env: &mut E) {
-        // Nothing to do
-    }
+    EXIT_SUCCESS
 }

--- a/src/spawn/builtin/false_cmd.rs
+++ b/src/spawn/builtin/false_cmd.rs
@@ -1,43 +1,16 @@
-use {EXIT_ERROR, ExitStatus, Spawn};
-use future::{Async, EnvFuture, Poll};
-use void::Void;
+use EXIT_ERROR;
 
-/// Represents a `false` builtin command.
-///
-/// The `false` command has no effect and always exits unsuccessfully.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct False;
+impl_trivial_builtin_cmd! {
+    /// Represents a `false` builtin command.
+    ///
+    /// The `false` command has no effect and always exits unsuccessfully.
+    pub struct False;
 
-/// Creates a new `false` builtin command.
-pub fn false_cmd() -> False {
-    False
-}
+    /// Creates a new `false` builtin command.
+    pub fn false_cmd();
 
-/// A future representing a fully spawned `false` builtin command.
-#[must_use = "futures do nothing unless polled"]
-#[derive(Debug)]
-#[allow(missing_copy_implementations)]
-pub struct SpawnedFalse;
+    /// A future representing a fully spawned `false` builtin command.
+    pub struct SpawnedFalse;
 
-impl<E: ?Sized> Spawn<E> for False {
-    type EnvFuture = SpawnedFalse;
-    type Future = ExitStatus;
-    type Error = Void;
-
-    fn spawn(self, _env: &E) -> Self::EnvFuture {
-        SpawnedFalse
-    }
-}
-
-impl<E: ?Sized> EnvFuture<E> for SpawnedFalse {
-    type Item = ExitStatus;
-    type Error = Void;
-
-    fn poll(&mut self, _env: &mut E) -> Poll<Self::Item, Self::Error> {
-        Ok(Async::Ready(EXIT_ERROR))
-    }
-
-    fn cancel(&mut self, _env: &mut E) {
-        // Nothing to do
-    }
+    EXIT_ERROR
 }

--- a/src/spawn/builtin/generic.rs
+++ b/src/spawn/builtin/generic.rs
@@ -1,0 +1,177 @@
+use {EXIT_ERROR, EXIT_SUCCESS, ExitStatus};
+use futures::{Async, Future, Poll};
+use void::Void;
+
+#[macro_export]
+macro_rules! impl_generic_builtin_cmd {
+    (
+        $(#[$cmd_attr:meta])*
+        pub struct $Cmd:ident;
+
+        $(#[$constructor_attr:meta])*
+        pub fn $constructor:ident ();
+
+        $(#[$spawned_future_attr:meta])*
+        pub struct $SpawnedFuture:ident;
+
+        $(#[$future_attr:meta])*
+        pub struct $Future:ident;
+
+        where T: $($t_bounds:path)+,
+    ) => {
+        impl_generic_builtin_cmd! {
+            $(#[$cmd_attr])*
+            pub struct $Cmd;
+
+            $(#[$constructor_attr])*
+            pub fn $constructor();
+
+            $(#[$spawned_future_attr])*
+            pub struct $SpawnedFuture;
+
+            $(#[$future_attr])*
+            pub struct $Future;
+
+            where T: $($t_bounds)+,
+                  E: ,
+        }
+    };
+
+    (
+        $(#[$cmd_attr:meta])*
+        pub struct $Cmd:ident;
+
+        $(#[$constructor_attr:meta])*
+        pub fn $constructor:ident ();
+
+        $(#[$spawned_future_attr:meta])*
+        pub struct $SpawnedFuture:ident;
+
+        $(#[$future_attr:meta])*
+        pub struct $Future:ident;
+
+        where T: $($t_bounds:path)+,
+              E: $($e_bounds:path)*,
+    ) => {
+        $(#[$cmd_attr])*
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        pub struct $Cmd<T> {
+            args: Vec<T>,
+        }
+
+        $(#[$constructor_attr])*
+        pub fn $constructor<T>(args: Vec<T>) -> $Cmd<T> {
+            $Cmd {
+                args: args,
+            }
+        }
+
+        $(#[$spawned_future_attr])*
+        #[must_use = "futures do nothing unless polled"]
+        #[derive(Debug)]
+        pub struct $SpawnedFuture<T> {
+            args: Option<Vec<T>>,
+        }
+
+        $(#[$future_attr])*
+        #[must_use = "futures do nothing unless polled"]
+        #[derive(Debug)]
+        pub struct $Future<W> {
+            inner: $crate::spawn::builtin::generic::WriteOutputFuture<W>,
+        }
+
+        impl<W> From<$crate::spawn::builtin::generic::WriteOutputFuture<W>> for $Future<W> {
+            fn from(inner: $crate::spawn::builtin::generic::WriteOutputFuture<W>) -> Self {
+                Self {
+                    inner: inner,
+                }
+            }
+        }
+
+        impl<T, E: ?Sized> $crate::Spawn<E> for $Cmd<T>
+            where T: $($t_bounds)*,
+                  E: $crate::env::AsyncIoEnvironment,
+                  E: $crate::env::FileDescEnvironment,
+                  E: $crate::env::ReportErrorEnvironment,
+                  E::FileHandle: ::std::borrow::Borrow<$crate::io::FileDesc>,
+                  E: $($e_bounds)*
+        {
+            type EnvFuture = $SpawnedFuture<T>;
+            type Future = $crate::spawn::ExitResult<$Future<E::WriteAll>>;
+            type Error = $crate::void::Void;
+
+            fn spawn(self, _env: &E) -> Self::EnvFuture {
+                $SpawnedFuture {
+                    args: Some(self.args)
+                }
+            }
+        }
+
+        impl<W> $crate::futures::Future for $Future<W>
+            where W: $crate::futures::Future
+        {
+            type Item = $crate::ExitStatus;
+            type Error = $crate::void::Void;
+
+            fn poll(&mut self) -> $crate::future::Poll<Self::Item, Self::Error> {
+                self.inner.poll()
+            }
+        }
+    }
+}
+
+macro_rules! generate_and_print_output {
+    ($env:expr, $generate:expr) => {{
+        let mut env = $env;
+
+        // If STDOUT is closed, just exit without doing more work
+        let stdout = match env.file_desc($crate::STDOUT_FILENO) {
+            Some((fdes, _)) => try_and_report!(fdes.borrow().duplicate(), env),
+            None => return Ok($crate::future::Async::Ready(EXIT_SUCCESS.into())),
+        };
+
+        let bytes = $crate::spawn::builtin::generic::generate_bytes__(&mut env, $generate);
+        let bytes = try_and_report!(bytes, env);
+        let bytes = env.write_all(stdout, bytes);
+
+        let future = $crate::spawn::builtin::generic::WriteOutputFuture::from(bytes);
+        Ok($crate::future::Async::Ready($crate::spawn::ExitResult::Pending(future.into())))
+    }};
+}
+
+pub(crate) fn generate_bytes__<E: ?Sized, F, ERR>(env: &mut E, generate: F)
+    -> Result<Vec<u8>, ERR>
+    where for<'a> F: FnOnce(&'a E) -> Result<Vec<u8>, ERR>
+{
+    generate(env)
+}
+
+#[must_use = "futures do nothing unless polled"]
+#[derive(Debug)]
+pub(crate) struct WriteOutputFuture<W> {
+    write_all: W,
+}
+
+impl<W> From<W> for WriteOutputFuture<W> {
+    fn from(inner: W) -> Self {
+        Self {
+            write_all: inner,
+        }
+    }
+}
+
+impl<W> Future for WriteOutputFuture<W>
+    where W: Future
+{
+    type Item = ExitStatus;
+    type Error = Void;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.write_all.poll() {
+            Ok(Async::Ready(_)) => Ok(Async::Ready(EXIT_SUCCESS)),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            // FIXME: report error anywhere? at least for debug logs?
+            Err(_) => Ok(Async::Ready(EXIT_ERROR)),
+        }
+    }
+}

--- a/src/spawn/builtin/mod.rs
+++ b/src/spawn/builtin/mod.rs
@@ -12,8 +12,8 @@ macro_rules! try_and_report {
     }
 }
 
-#[macro_use]
-mod trivial;
+#[macro_use] mod generic;
+#[macro_use] mod trivial;
 
 mod colon;
 mod echo;

--- a/src/spawn/builtin/mod.rs
+++ b/src/spawn/builtin/mod.rs
@@ -12,16 +12,19 @@ macro_rules! try_and_report {
     }
 }
 
+#[macro_use]
+mod trivial;
+
 mod colon;
-mod false_cmd;
 mod echo;
+mod false_cmd;
 mod pwd;
 mod shift;
 mod true_cmd;
 
 pub use self::colon::{Colon, colon, SpawnedColon};
-pub use self::false_cmd::{False, false_cmd, SpawnedFalse};
 pub use self::echo::{Echo, echo, EchoFuture, SpawnedEcho};
+pub use self::false_cmd::{False, false_cmd, SpawnedFalse};
 pub use self::pwd::{Pwd, pwd, PwdFuture, SpawnedPwd};
 pub use self::shift::{Shift, shift, SpawnedShift};
 pub use self::true_cmd::{True, true_cmd, SpawnedTrue};

--- a/src/spawn/builtin/pwd.rs
+++ b/src/spawn/builtin/pwd.rs
@@ -29,8 +29,9 @@ impl_generic_builtin_cmd! {
           E: WorkingDirectoryEnvironment,
 }
 
-impl<T, E: ?Sized> EnvFuture<E> for SpawnedPwd<T>
+impl<T, I, E: ?Sized> EnvFuture<E> for SpawnedPwd<I>
     where T: StringWrapper,
+          I: Iterator<Item = T>,
           E: AsyncIoEnvironment
               + FileDescEnvironment
               + ReportErrorEnvironment

--- a/src/spawn/builtin/trivial.rs
+++ b/src/spawn/builtin/trivial.rs
@@ -1,0 +1,55 @@
+/// Implements a builtin command which accepts no arguments,
+/// has no side effects, and simply exits with some status.
+#[macro_export]
+macro_rules! impl_trivial_builtin_cmd {
+    (
+        $(#[$cmd_attr:meta])*
+        pub struct $Cmd:ident;
+
+        $(#[$constructor_attr:meta])*
+        pub fn $constructor:ident ();
+
+        $(#[$future_attr:meta])*
+        pub struct $Future:ident;
+
+        $exit:expr
+    ) => {
+        $(#[$cmd_attr])*
+        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+        pub struct $Cmd;
+
+        $(#[$constructor_attr])*
+        pub fn $constructor() -> $Cmd {
+            $Cmd
+        }
+
+        $(#[$future_attr])*
+        #[must_use = "futures do nothing unless polled"]
+        #[derive(Debug)]
+        #[allow(missing_copy_implementations)]
+        pub struct $Future;
+
+        impl<E: ?Sized> $crate::Spawn<E> for $Cmd {
+            type EnvFuture = $Future;
+            type Future = $crate::ExitStatus;
+            type Error = $crate::void::Void;
+
+            fn spawn(self, _env: &E) -> Self::EnvFuture {
+                $Future
+            }
+        }
+
+        impl<E: ?Sized> $crate::future::EnvFuture<E> for $Future {
+            type Item = $crate::ExitStatus;
+            type Error = $crate::void::Void;
+
+            fn poll(&mut self, _env: &mut E) -> $crate::future::Poll<Self::Item, Self::Error> {
+                Ok($crate::future::Async::Ready($exit))
+            }
+
+            fn cancel(&mut self, _env: &mut E) {
+                // Nothing to do
+            }
+        }
+    }
+}

--- a/src/spawn/builtin/true_cmd.rs
+++ b/src/spawn/builtin/true_cmd.rs
@@ -1,44 +1,16 @@
-use {EXIT_SUCCESS, ExitStatus, Spawn};
-use future::{Async, EnvFuture, Poll};
-use void::Void;
+use EXIT_SUCCESS;
 
-/// Represents a `true` builtin command.
-///
-/// The `true` command has no effect and always exits successfully.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct True;
+impl_trivial_builtin_cmd! {
+    /// Represents a `true` builtin command.
+    ///
+    /// The `true` command has no effect and always exits successfully.
+    pub struct True;
 
-/// Creates a new `true` builtin command.
-pub fn true_cmd() -> True {
-    True
+    /// Creates a new `true` builtin command.
+    pub fn true_cmd();
+
+    /// A future representing a fully spawned `true` builtin command.
+    pub struct SpawnedTrue;
+
+    EXIT_SUCCESS
 }
-
-/// A future representing a fully spawned `true` builtin command.
-#[must_use = "futures do nothing unless polled"]
-#[derive(Debug)]
-#[allow(missing_copy_implementations)]
-pub struct SpawnedTrue;
-
-impl<E: ?Sized> Spawn<E> for True {
-    type EnvFuture = SpawnedTrue;
-    type Future = ExitStatus;
-    type Error = Void;
-
-    fn spawn(self, _env: &E) -> Self::EnvFuture {
-        SpawnedTrue
-    }
-}
-
-impl<E: ?Sized> EnvFuture<E> for SpawnedTrue {
-    type Item = ExitStatus;
-    type Error = Void;
-
-    fn poll(&mut self, _env: &mut E) -> Poll<Self::Item, Self::Error> {
-        Ok(Async::Ready(EXIT_SUCCESS))
-    }
-
-    fn cancel(&mut self, _env: &mut E) {
-        // Nothing to do
-    }
-}
-

--- a/tests/echo.rs
+++ b/tests/echo.rs
@@ -10,10 +10,6 @@ mod support;
 pub use self::support::*;
 
 fn run_echo(args: &[&str]) -> String {
-    let args = args.iter()
-        .map(|&s| s.to_owned())
-        .collect();
-
     let (mut lp, mut env) = new_env_with_threads(2);
 
     let pipe = Pipe::new().expect("pipe failed");
@@ -21,7 +17,7 @@ fn run_echo(args: &[&str]) -> String {
 
     let read_to_end = tokio_io::io::read_to_end(env.read_async(pipe.reader), Vec::new());
 
-    let echo = builtin::echo(args)
+    let echo = builtin::echo(args.iter().map(|&s| s.to_owned()))
         .spawn(&env)
         .pin_env(env)
         .flatten()

--- a/tests/pwd.rs
+++ b/tests/pwd.rs
@@ -72,10 +72,7 @@ fn run_pwd(use_dots: bool, pwd_args: &[&str], physical_result: bool) {
         fn_error: PhantomData as PhantomData<RuntimeError>,
     });
 
-    let pwd = builtin::pwd(pwd_args.iter()
-        .map(|&s| s.to_owned())
-        .collect()
-    );
+    let pwd = builtin::pwd(pwd_args.iter().map(|&s| s.to_owned()));
 
     let pipe = Pipe::new().expect("pipe failed");
     env.set_file_desc(conch_runtime::STDOUT_FILENO, pipe.writer.into(), Permissions::Write);

--- a/tests/shift.rs
+++ b/tests/shift.rs
@@ -20,10 +20,7 @@ fn run_shift(
         .collect::<Vec<_>>()
     ));
 
-    let shift = builtin::shift(shift_args.iter()
-        .map(|&s| s.to_owned())
-        .collect()
-    );
+    let shift = builtin::shift(shift_args.iter().map(|&s| s.to_owned()));
 
     let mut shift = shift.spawn(&env);
     let exit = lp.run(poll_fn(|| shift.poll(&mut env)).flatten())


### PR DESCRIPTION
* Introduce a macro for generating generic builtins which take some arguments, do some processing, and then print something to stdout
* Also changed existing builtins from taking a `Vec<T>` to just taking an `I: Iterator<Item = T>` instead