### PR TITLE
Fixed the behavior of an unset `$PATH` variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ script:
   - cargo check
     # Retry with fewer cores if the initial `cargo test` fails to work around possible OOM errors
     # for more details see https://github.com/rust-lang/cargo/issues/4415
-  - cargo test --no-fail-fast ||
+  - travis_wait cargo test --no-fail-fast ||
     (
       echo 'initial `cargo test` failed, retrying with fewer cores to work around OOM issues' &&
-      cargo test --no-fail-fast --verbose -j 1
+      travis_wait cargo test --no-fail-fast -j 1
     )
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,11 @@ variable assignments (e.g. `var1=foo var2=${bar:-$var1} env`) but cannot be amme
 introducing breaking changes
 
 ### Removed
+
 ### Fixed
+- Fixed the behavior of an unset `$PATH` variable to behave like other shells (i.e. raises command
+not found errors) instead of using the `PATH` env variable of the current process
+
 ### Security
 ### Breaking
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,6 @@ environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
     RUST_VERSION: nightly
-  - TARGET: x86_64-pc-windows-gnu
-    RUST_VERSION: nightly
 
 branches:
   only:

--- a/src/spawn/simple.rs
+++ b/src/spawn/simple.rs
@@ -469,10 +469,6 @@ fn spawn_process<T, F, VN, V, E: ?Sized>(
         }
     };
 
-    // FIXME: ensure that command name is an absolute path (i.e. based on env
-    // cwd, not the process' cwd) so spawning does not end up using the process cwd
-    // to select the executable
-    // FIXME: also need to honor $PATH variable here
     let data = ExecutableData {
         name: name,
         args: args,

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -215,9 +215,9 @@ fn command_redirect_and_env_var_overrides() {
     let stdout = tokio_io::io::read_to_end(env.read_async(pipe.reader), Vec::new())
         .map(|(_, msg)| {
             if cfg!(windows) {
-                assert_eq!(msg, "KEY=val\nKEY_EXISTING=val_existing\n".as_bytes());
+                assert_eq!(msg, "KEY=val\nKEY_EXISTING=val_existing\nPATH=\n".as_bytes());
             } else {
-                assert_eq!(msg, "key=val\nkey_existing=val_existing\n".as_bytes());
+                assert_eq!(msg, "PATH=\nkey=val\nkey_existing=val_existing\n".as_bytes());
             }
         })
         .map_err(|e| panic!("stdout failed: {}", e));


### PR DESCRIPTION
* Behavior of an unset `$PATH` variable will now raise command not found errors
instead of using the `PATH` env variable of the current process