### PR TITLE
Update builtin commands to print out their name on error

### DIFF
--- a/src/spawn/builtin/echo.rs
+++ b/src/spawn/builtin/echo.rs
@@ -47,7 +47,7 @@ impl<T, I, E: ?Sized> EnvFuture<E> for SpawnedEcho<I>
             .fuse()
             .peekable();
 
-        generate_and_print_output!(env, |_| -> Result<_, Void> {
+        generate_and_print_output!("echo", env, |_| -> Result<_, Void> {
             let (flags, args) = parse_args(args);
             Ok(generate_output(flags, args.into_iter().flat_map(|a| a)))
         })

--- a/src/spawn/builtin/generic.rs
+++ b/src/spawn/builtin/generic.rs
@@ -155,17 +155,18 @@ macro_rules! impl_generic_builtin_cmd {
 }
 
 macro_rules! generate_and_print_output {
-    ($env:expr, $generate:expr) => {{
+    ($name:expr, $env:expr, $generate:expr) => {{
+        let name = $name;
         let mut env = $env;
 
         // If STDOUT is closed, just exit without doing more work
         let stdout = match env.file_desc($crate::STDOUT_FILENO) {
-            Some((fdes, _)) => try_and_report!(fdes.borrow().duplicate(), env),
+            Some((fdes, _)) => try_and_report!(name, fdes.borrow().duplicate(), env),
             None => return Ok($crate::future::Async::Ready(EXIT_SUCCESS.into())),
         };
 
         let bytes = $crate::spawn::builtin::generic::generate_bytes__(&mut env, $generate);
-        let bytes = try_and_report!(bytes, env);
+        let bytes = try_and_report!(name, bytes, env);
         let bytes = env.write_all(stdout, bytes);
 
         let future = $crate::spawn::builtin::generic::WriteOutputFuture::from(bytes);

--- a/src/spawn/builtin/mod.rs
+++ b/src/spawn/builtin/mod.rs
@@ -1,11 +1,19 @@
 //! Defines methods for spawning shell builtin commands
 
+use std::error::Error;
+use std::fmt;
+
 macro_rules! try_and_report {
-    ($result:expr, $env:ident) => {
+    ($name:expr, $result:expr, $env:ident) => {
         match $result {
             Ok(val) => val,
             Err(e) => {
-                $env.report_error(&e);
+                let err = $crate::spawn::builtin::ErrorWithBuiltinName {
+                    name: $name,
+                    err: e,
+                };
+
+                $env.report_error(&err);
                 return Ok($crate::future::Async::Ready(EXIT_ERROR.into()));
             },
         }
@@ -30,3 +38,25 @@ pub use self::false_cmd::{False, false_cmd, SpawnedFalse};
 pub use self::pwd::{Pwd, pwd, PwdFuture, SpawnedPwd};
 pub use self::shift::{Shift, shift, SpawnedShift};
 pub use self::true_cmd::{True, true_cmd, SpawnedTrue};
+
+#[derive(Debug)]
+struct ErrorWithBuiltinName<T> {
+    name: &'static str,
+    err: T,
+}
+
+impl<T: Error> Error for ErrorWithBuiltinName<T> {
+    fn description(&self) -> &str {
+        self.err.description()
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        Some(&self.err)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for ErrorWithBuiltinName<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}: {}", self.name, self.err)
+    }
+}

--- a/src/spawn/builtin/pwd.rs
+++ b/src/spawn/builtin/pwd.rs
@@ -42,10 +42,11 @@ impl<T, I, E: ?Sized> EnvFuture<E> for SpawnedPwd<I>
     type Error = Void;
 
     fn poll(&mut self, env: &mut E) -> Poll<Self::Item, Self::Error> {
+        const PWD: &str = "pwd";
         const ARG_LOGICAL: &str = "L";
         const ARG_PHYSICAL: &str = "P";
 
-        let app = App::new("pwd")
+        let app = App::new(PWD)
             .setting(AppSettings::NoBinaryName)
             .setting(AppSettings::DisableVersion)
             .about("Prints the absolute path name of the current working directory")
@@ -67,9 +68,9 @@ impl<T, I, E: ?Sized> EnvFuture<E> for SpawnedPwd<I>
             .into_iter()
             .map(StringWrapper::into_owned);
 
-        let matches = try_and_report!(app.get_matches_from_safe(app_args), env);
+        let matches = try_and_report!(PWD, app.get_matches_from_safe(app_args), env);
 
-        generate_and_print_output!(env, |env| {
+        generate_and_print_output!(PWD, env, |env| {
             let mut cwd_bytes = if matches.is_present(ARG_PHYSICAL) {
                 physical(env.current_working_dir())
             } else {

--- a/src/spawn/builtin/shift.rs
+++ b/src/spawn/builtin/shift.rs
@@ -76,10 +76,11 @@ impl<T, I, E: ?Sized> EnvFuture<E> for SpawnedShift<I>
     type Error = Void;
 
     fn poll(&mut self, env: &mut E) -> Poll<Self::Item, Self::Error> {
+        const SHIFT: &str = "shift";
         const AMT_ARG_NAME: &str = "n";
         const DEFAULT_SHIFT_AMOUNT: &str = "1";
 
-        let app = App::new("shift")
+        let app = App::new(SHIFT)
             .setting(AppSettings::NoBinaryName)
             .setting(AppSettings::DisableVersion)
             .about("Shifts positional parameters such that (n+1)th parameter becomes $1, and so on")
@@ -99,14 +100,14 @@ impl<T, I, E: ?Sized> EnvFuture<E> for SpawnedShift<I>
             .into_iter()
             .map(StringWrapper::into_owned);
 
-        let matches = try_and_report!(app.get_matches_from_safe(app_args), env);
+        let matches = try_and_report!(SHIFT, app.get_matches_from_safe(app_args), env);
 
         let amt_arg = matches.value_of_lossy(AMT_ARG_NAME)
             .unwrap_or(Cow::Borrowed(DEFAULT_SHIFT_AMOUNT))
             .parse()
             .map_err(|_| NumericArgumentRequiredError);
 
-        let amt = try_and_report!(amt_arg, env);
+        let amt = try_and_report!(SHIFT, amt_arg, env);
 
         let ret = if amt > env.args_len() {
             EXIT_ERROR


### PR DESCRIPTION
* For example, errors from builtin commands will look like
`shell-name: builtin-cmd: error msg` instead of
`shell-name: error msg`