### PR TITLE
Fix EventedAsyncIoEnv to handle regular files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ backwards compatible manner.
  - `pwd`
  - `echo`
 - Added a `NormalizedPath` wrapper for working with logically or physically normalized paths
+- Added `FileDescExt::into_evented2` which gracefully handles regular files (which cannot be
+registered with tokio)
 
 ### Changed
 - Reduced required bounds for implementing `VarEnvRestorer` to just `E: VariableEnvironment`
@@ -34,10 +36,13 @@ amounts of redirects when they do occur, so we can avoid allocating memory until
 and `EvalRedirectOrVarAssig`: the existing implementation does not handle referencing earlier
 variable assignments (e.g. `var1=foo var2=${bar:-$var1} env`) but cannot be ammended without
 introducing breaking changes
+- Deprecated `FileDescExt::into_evented` since it does not handle regular files gracefully
 
 ### Removed
 
 ### Fixed
+- `EventedAsyncIoEnv` gracefully handles regular files by not registering them with tokio
+(since epoll/kqueue do not support registering regular files)
 - Fixed the behavior of an unset `$PATH` variable to behave like other shells (i.e. raises command
 not found errors) instead of using the `PATH` env variable of the current process
 

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -5,7 +5,7 @@
 pub mod unix {
     /// Unix-specific extensions around general I/O.
     pub mod io {
-        pub use sys::io::{EventedFileDesc, FileDescExt};
+        pub use sys::io::{EventedFileDesc, FileDescExt, MaybeEventedFd};
     }
 
     /// Unix-specific environment extensions

--- a/src/sys/unix/io/mod.rs
+++ b/src/sys/unix/io/mod.rs
@@ -12,7 +12,7 @@ use std::process::Stdio;
 
 mod fd_ext;
 
-pub use self::fd_ext::{EventedFileDesc, FileDescExt};
+pub use self::fd_ext::{EventedFileDesc, FileDescExt, MaybeEventedFd};
 
 /// A wrapper around an owned UNIX file descriptor. The wrapper
 /// allows reading from or write to the descriptor, and will
@@ -134,6 +134,7 @@ impl RawIo {
     }
 
     /// Sets the `O_NONBLOCK` flag on the descriptor to the desired state.
+    // FIXME(breaking): require a mut ref here, avoids having someone else change the flag under us
     pub fn set_nonblock(&self, set: bool) -> Result<()> {
         unsafe {
             let flags = try!(cvt_r(|| libc::fcntl(self.fd, libc::F_GETFL)));


### PR DESCRIPTION
* The OS backing of tokio event loops don't support regular files which
results in errors whenever a registration is attempted
* We now attempt to check if the opened file descriptor points to a
regular file, and if so, we don't register it with tokio and treat it as
if it is always ready for IO