### PR TITLE
Don't use std::ptr::Unique on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    RUST_VERSION: nightly
+    RUST_VERSION: stable
 
 branches:
   only:

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -128,3 +128,15 @@ pub(crate) fn dup_stdio() -> Result<(FileDesc, FileDesc, FileDesc)> {
         FileDesc::from_inner(stderr)
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_file_desc_is_send_and_sync() {
+        fn send_and_sync<T: Send + Sync>() {}
+
+        send_and_sync::<FileDesc>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,6 @@
 #![deny(unused_import_braces)]
 #![deny(unused_qualifications)]
 
-#![cfg_attr(windows, feature(ptr_internals))]
-
 // Unix only libs
 #[cfg(unix)] extern crate libc;
 

--- a/src/sys/unix/io/mod.rs
+++ b/src/sys/unix/io/mod.rs
@@ -17,16 +17,10 @@ pub use self::fd_ext::{EventedFileDesc, FileDescExt, MaybeEventedFd};
 /// A wrapper around an owned UNIX file descriptor. The wrapper
 /// allows reading from or write to the descriptor, and will
 /// close it once it goes out of scope.
-#[derive(Debug, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct RawIo {
     /// The underlying descriptor.
     fd: RawFd,
-}
-
-impl PartialEq<RawIo> for RawIo {
-    fn eq(&self, other: &RawIo) -> bool {
-        self.fd == other.fd
-    }
 }
 
 impl Into<Stdio> for RawIo {


### PR DESCRIPTION
* Unique is currently unstable and its future isn't clear
* Unique gives us Send + Sync and handles variance for us, however,
since we aren't using generic pointers (i.e. we only use *mut c_void) we
can just impl Send + Sync ourselves
* Since we own the HANDLE and don't share any ownership of it, it should
be safe to be Send
* Since the OS locking around modifying HANDLE attributes will handle
synchronization, it should be safe to be Sync
* This change also allows us to support Windows builds on the stable
toolchain (changed appveyor to use stable instead of nightly)