### PR TITLE
Fixed dead examples link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ way Windows addresses file handles).
 
 [POSIX]: http://pubs.opengroup.org/onlinepubs/9699919799/
 [conch-parser]: https://docs.rs/conch-parser
-[shell-example]: https://github.com/ipetkov/conch-runtime/blob/master/examples/shell.rs
+[shell-example]: https://github.com/ipetkov/conch-runtime/blob/master/conch-runtime/examples/shell.rs
 
 ### Goals
 * Provide efficient, modularized implementations of executing parts of the shell


### PR DESCRIPTION
I tried clicking on the example link but it currently leads to a GitHub 404 page.

This PR points the link to what I believe is the correct directory :)